### PR TITLE
Use gg to support folded rows

### DIFF
--- a/autoload/edgemotion.vim
+++ b/autoload/edgemotion.vim
@@ -51,8 +51,7 @@ function! edgemotion#move(dir) abort
     return ''
   endif
 
-  let move_cmd = a:dir is# s:DIRECTION.FORWARD ? 'j' : 'k'
-  return abs(lnum-orig_lnum) . move_cmd
+  return lnum . 'gg'
 endfunction
 
 function! s:island(lnum, vcol) abort

--- a/test/edgemotion.vimspec
+++ b/test/edgemotion.vimspec
@@ -42,14 +42,14 @@ Describe edgemotion
       Assert Equals(getline('.'), 'function! s:f() abort')
       Assert Equals(CursorChar(), 'f')
       let move_cmds = edgemotion#move(s:DIRECTION.FORWARD)
-      Assert Equals(move_cmds, '7j')
+      Assert Equals(move_cmds, '10gg')
       execute 'normal!' move_cmds
       Assert Equals(getline('.'), 'endfunction')
       Assert Equals(CursorChar(), 'e')
 
       " endfunction to function
       let move_cmds = edgemotion#move(s:DIRECTION.BACKWARD)
-      Assert Equals(move_cmds, '7k')
+      Assert Equals(move_cmds, '3gg')
       execute 'normal!' move_cmds
       Assert Equals(getline('.'), 'function! s:f() abort')
       Assert Equals(CursorChar(), 'f')


### PR DESCRIPTION
Move using j/k does not work correctly when there are folded rows; fixed by moving directly to the line number using gg.